### PR TITLE
Camel case fix

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -117,6 +117,7 @@ pub struct Datablock {
 /// [`Datablock`]: struct.Datablock.html
 /// [`time`]: #structfield.time
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct Datapoint {
     pub apparent_temperature_max_time: Option<u64>,
     pub apparent_temperature_max: Option<f64>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -174,6 +174,7 @@ pub struct Datapoint {
 /// [`Unit`]: enum.Unit.html
 /// [DarkSky]: https://darksky.net
 #[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(rename_all="kebab-case")]
 pub struct Flags {
     /// A list of DarkSky stations used for the [`Forecast`].
     ///


### PR DESCRIPTION
Hello,

Warning: I hadn't touched rust before today.

This PR appears to fix an issue where datapoint fields with names consisting of multiple words (snake case in the models.rs, camelCase from the darksky json) aren't populated with values.

It also gives a similar treatment to Flags, which is inexplicably kebab-cased in the json.

daily datapoint before:
```    temperature_max_error: None,
    temperature_max_time: None,
    temperature_max: None,
    temperature_min_error: None,
    temperature_min_time: None,
    temperature_min: None,
    temperature_error: None,
    temperature: None,
```

daily datapoint after:

```    temperature_max_error: None,
    temperature_max_time: Some(
        1502665200
    ),
    temperature_max: Some(
        71.35
    ),
    temperature_min_error: None,
    temperature_min_time: Some(
        1502625600
    ),
    temperature_min: Some(
        57.99
    ),
    temperature_error: None,
    temperature: None,
```

flags before:

```
    darksky_stations: None,
    darksky_unavailable: None,
    datapoint_stations: None,
    isd_stations: None,
    lamp_stations: None,
    metar_stations: None,
    metno_license: None,
    sources: Some(
        [
            "isd",
            "nearest-precip",
            "cmc",
            "gfs",
            "hrrr",
            "madis",
            "nam",
            "sref",
            "darksky"
        ]
    ),
    units: Some(
        "us"
    )
```

flags after:

```
    darksky_stations: None,
    darksky_unavailable: None,
    datapoint_stations: None,
    isd_stations: Some(
        [
            "722748-03914",
            "722748-99999",
            "722749-53128",
            "722749-99999",
            "722780-23183",
            "722783-03185",
            "722783-99999",
            "722784-03184",
            "722784-99999",
            "722786-23104",
            "722789-03192",
            "722789-99999",
            "749167-99999",
            "749173-99999",
            "999999-23183",
            "999999-93140"
        ]
    ),
    lamp_stations: None,
    metar_stations: None,
    metno_license: None,
    sources: Some(
        [
            "isd",
            "nearest-precip",
            "cmc",
            "gfs",
            "hrrr",
            "madis",
            "nam",
            "sref",
            "darksky"
        ]
    ),
    units: Some(
        "us"
    )
```